### PR TITLE
feat(dbt): add dataQualityAssertions coverage to csv_to_postgres scenario

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,4 +173,5 @@ bin/
 **/specs/
 **/output/
 **/test/openlineage.yml
+**/events/*.jsonl
 dbt_producer_report.json

--- a/producer/dbt/README.md
+++ b/producer/dbt/README.md
@@ -13,23 +13,21 @@ It is important to note that this is a **compatibility validation framework** us
 
 ## Test Architecture and Workflow
 
-The test is orchestrated by the `run_dbt_tests.sh` script and follows a clear, sequential workflow designed for reliability and ease of use. This structure ensures that each component of the integration is validated systematically.
+The test is orchestrated by the scenario's `test/run.sh` script and follows a clear, sequential workflow designed for reliability and ease of use. This structure ensures that each component of the integration is validated systematically.
 
 The end-to-end process is as follows:
 
-1.  **Test Orchestration**: The `run_dbt_tests.sh` script serves as the main entry point. It sets up the environment and initiates over the scenarios folder to execute each test scenario.
+1.  **Scenario Execution**: The `test/run.sh` script executes the dbt project defined in the `runner/` directory using `dbt-ol seed`, `dbt-ol run`, and `dbt-ol test`.
 
-2.  **Scenario Execution**: The test runner executes the dbt project defined in the `runner/` directory. The specific dbt commands to be run (e.g., `dbt seed`, `dbt run`, `dbt test`) are defined in the test scenarios run script (`test/run.sh`).
-
-3.  **Event Generation and Capture**: During the execution, the `dbt-ol` wrapper intercepts the dbt commands and emits OpenLineage events. The `test/openlineage.yml` configuration directs these events to be captured as a local file (`{directory_input_param}/events.jsonl`) using the `file` transport.
+2.  **Event Generation and Capture**: During the execution, the `dbt-ol` wrapper intercepts the dbt commands and emits OpenLineage events. The `test/run.sh` script writes an `openlineage.yml` configuration that directs these events to be captured as a local file (`{output_dir}/events.jsonl`) using the `file` transport.
  
-4.  **Extract events**: OpenLineage emits events reliable to one file ('append: true' causes overwrites and events to be lost) so it is required to extract the before validation.
+3.  **Extract events**: OpenLineage emits all events to one file, so `run.sh` splits them into individual numbered files (`event-1.json`, `event-2.json`, …) before deleting the combined `.jsonl`.
 
-5.  **Event Validation**: Once the dbt process is complete, the test framework performs a two-stage validation on the generated events:
-    *   **Syntax Validation**: Each event is validated against the official OpenLineage JSON schema (e.g., version `1.40.1`) to ensure it is structurally correct.
-    *   **Semantic Validation**: The content of the events is compared against expected templates. This deep comparison, powered by the `scripts/compare_events.py` utility, verifies the accuracy of job names, dataset identifiers, lineage relationships, and the presence and structure of key facets.
+4.  **Event Validation**: Once the dbt process is complete, the shared framework (`scripts/validate_ol_events.py`) performs a two-stage validation on the generated events:
+    *   **Syntax Validation**: Each event is validated against the official OpenLineage JSON schema to ensure it is structurally correct.
+    *   **Semantic Validation**: The content of the events is compared against expected templates in `scenarios/csv_to_postgres/events/`. This comparison, powered by the `scripts/compare_events.py` utility, verifies the accuracy of job names, dataset identifiers, lineage relationships, and the presence and structure of key facets.
 
-6.  **Reporting**: Upon completion, the test runner generates a standardized JSON report (`dbt_producer_report.json`) that details the results of each validation step. This report is designed to be consumed by higher-level aggregation scripts in a CI/CD environment.
+5.  **Reporting**: Upon completion, the framework generates a standardised JSON report that details the results of each validation step for consumption by CI/CD aggregation scripts.
 
 ## Validation Scope
 
@@ -38,6 +36,7 @@ This test validates that the `openlineage-dbt` integration correctly generates O
 #### dbt Operations Covered:
 -   `dbt seed`: To load initial data.
 -   `dbt run`: To execute dbt models.
+-   `dbt test`: To run data quality tests and capture `dataQualityAssertions` facets.
 
 #### Validation Checks:
 -   **Event Generation**: Correctly creates `START` and `COMPLETE` events for jobs and runs.
@@ -50,6 +49,7 @@ This test validates that the `openlineage-dbt` integration correctly generates O
     -   `schema`
     -   `dataSource`
     -   `columnLineage`
+    -   `dataQualityAssertions`
 -   **Specification Compliance**: Events are validated against the OpenLineage specification schema (version `2-0-2`).
 
 ## Test Structure
@@ -58,16 +58,14 @@ The test is organized into the following key directories, each with a specific r
 
 ```
 producer/dbt/
-├── run_dbt_tests.sh           # Main test execution script
-├── scenarios/                 # Defines the dbt commands and expected outcomes for each test case
-├── output/                    # Default output directory for generated OpenLineage events (generated during execution)
+├── scenarios/                 # Test scenarios; each defines expected events and a run script
 ├── runner/                    # A self-contained dbt project used as the test target
-└── specs/                     # Stores OpenLineage spcification get from local repository (generated during execution)
+├── versions.json              # Supported component and OpenLineage version ranges
+└── maintainers.json           # Maintainer contact information
 ```
 
 -   **`runner/`**: A self-contained dbt project with models, seeds, and configuration. This is the target of the `dbt-ol` command.
--   **`scenarios/`**: Defines the dbt commands to be executed and contains the expected event templates for validation.
--   **`output/`**: The default output directory for the generated `events.jsonl` file and extracted events.
+-   **`scenarios/`**: Contains one directory per scenario. Each scenario has a `config.json` defining expected event templates, an `events/` directory of expected event JSON files, and a `test/` directory with `run.sh` and `compose.yml`.
 
 ## How to Run the Tests
 
@@ -106,36 +104,33 @@ The GitHub Actions workflow:
 
 If you need to debug event generation locally:
 
-1.  **Ensure Docker is running**:
-    - The scenario runner uses `producer/dbt/scenarios/csv_to_postgres/test/compose.yml`.
-    - If PostgreSQL is not already available on `localhost:5432`, the scenario script starts the local Docker Compose service automatically and waits until it is ready.
+1.  **Ensure Docker is available**:
+    - The scenario runner will start the local Docker Compose Postgres service automatically if it is not already reachable on `localhost:5432`.
 
-2.  **Install Python Dependencies**:
+2.  **Install dbt and the OpenLineage wrapper** (use a virtual environment outside the repo):
     ```bash
-    # Activate virtual environment (recommended)
-    python -m venv venv
-    source venv/bin/activate  # On Windows: venv\Scripts\activate
+    python -m venv ~/.venvs/dbt-compat-test
+    source ~/.venvs/dbt-compat-test/bin/activate
+    pip install dbt-core==1.8.0 dbt-postgres openlineage-dbt==1.23.0
     ```
     
-3.  **Run Test Scenario**:
-    - The example below assumes you run the command from the repository root, so relative paths such as `./producer/dbt/output` and `./dbt_producer_report.json` resolve from that location.
+3.  **Run the dbt producer test harness**:
+    - Run this from the repository root so the default output paths resolve correctly.
     ```bash
     ./producer/dbt/run_dbt_tests.sh \
-      --openlineage-directory <open_lineage_directory> \
+      --openlineage-directory /path/to/OpenLineage \
       --producer-output-events-dir ./producer/dbt/output \
-      --openlineage-release 1.45.0
+      --openlineage-release 1.45.0 \
+      --report-path ./dbt_producer_report.json
     ```
 
-4.  **Inspect Generated Events**:
+4.  **Inspect generated events**:
     ```bash
-    # View events
     cat ./producer/dbt/output/csv_to_postgres/event-{id}.json | jq '.'
-    
-    # check report
     cat ./dbt_producer_report.json | jq '.'
     ```
 
-**Note**: Local debugging is entirely optional. All official validation happens in GitHub Actions with PostgreSQL service containers. Local runs now reuse the same PostgreSQL 15 image and readiness check as CI to reduce drift between local debugging and workflow execution.
+**Note**: Local debugging is entirely optional. All official validation happens in GitHub Actions with PostgreSQL service containers. The `run_dbt_tests.sh` wrapper uses the same scenario scripts and validation pipeline as CI, including the merged local test-aid improvements from #283.
 
 ## Important dbt Integration Notes
 

--- a/producer/dbt/README.md
+++ b/producer/dbt/README.md
@@ -123,6 +123,7 @@ If you need to debug event generation locally:
       --openlineage-release 1.45.0 \
       --report-path ./dbt_producer_report.json
     ```
+        - The harness installs dbt runner dependencies into your active venv and creates a separate temporary validation venv for `scripts/requirements.txt`, so the shared validation stack does not downgrade dbt packages mid-run.
 
 4.  **Inspect generated events**:
     ```bash
@@ -130,7 +131,7 @@ If you need to debug event generation locally:
     cat ./dbt_producer_report.json | jq '.'
     ```
 
-**Note**: Local debugging is entirely optional. All official validation happens in GitHub Actions with PostgreSQL service containers. The `run_dbt_tests.sh` wrapper uses the same scenario scripts and validation pipeline as CI, including the merged local test-aid improvements from #283.
+**Note**: Local debugging is entirely optional. All official validation happens in GitHub Actions with PostgreSQL service containers. The `run_dbt_tests.sh` wrapper uses the same scenario scripts and validation pipeline as CI, including the merged local test-aid improvements from #283, while isolating validation-only dependencies from the dbt runtime environment.
 
 ## Important dbt Integration Notes
 

--- a/producer/dbt/run_dbt_tests.sh
+++ b/producer/dbt/run_dbt_tests.sh
@@ -7,6 +7,8 @@ SCENARIOS_DIR="$DBT_DIR/scenarios"
 RUNNER_REQUIREMENTS="$DBT_DIR/runner/requirements.txt"
 SPECS_BASE_DIR="$DBT_DIR/specs"
 SCRIPTS_DIR="$REPO_ROOT/scripts"
+VALIDATION_VENV_DIR="${DBT_VALIDATION_VENV_DIR:-}"
+VALIDATION_VENV_IS_TEMP=0
 
 resolve_path() {
     local input_path="$1"
@@ -20,6 +22,29 @@ resolve_path() {
         echo "$base_dir/$input_path"
     fi
 }
+
+cleanup_validation_venv() {
+    if [[ "$VALIDATION_VENV_IS_TEMP" -eq 1 && -n "$VALIDATION_VENV_DIR" && -d "$VALIDATION_VENV_DIR" ]]; then
+        rm -rf "$VALIDATION_VENV_DIR"
+    fi
+}
+
+ensure_validation_venv() {
+    if [[ -z "$VALIDATION_VENV_DIR" ]]; then
+        VALIDATION_VENV_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dbt-validation-venv.XXXXXX")"
+        VALIDATION_VENV_IS_TEMP=1
+    fi
+
+    if [[ ! -x "$VALIDATION_VENV_DIR/bin/python" ]]; then
+        python -m venv "$VALIDATION_VENV_DIR"
+    fi
+
+    echo "Preparing isolated validation environment"
+    "$VALIDATION_VENV_DIR/bin/python" -m pip install --upgrade pip
+    "$VALIDATION_VENV_DIR/bin/python" -m pip install -r "$SCRIPTS_DIR/requirements.txt"
+}
+
+trap cleanup_validation_venv EXIT
 
 ################################################################################
 ############ dbt Producer Compatibility Test Execution Script ################
@@ -107,7 +132,7 @@ fi
 python -m pip install --upgrade pip
 
 if [ -f "$RUNNER_REQUIREMENTS" ]; then
-  pip install -r "$RUNNER_REQUIREMENTS"
+    python -m pip install -r "$RUNNER_REQUIREMENTS"
 fi
 
 ################################################################################
@@ -158,9 +183,9 @@ if [ -z "$(ls -A "$DEST_DIR")" ]; then
     exit 1
 fi
 
-pip install -r "$SCRIPTS_DIR/requirements.txt"
+ensure_validation_venv
 
-python "$SCRIPTS_DIR/validate_ol_events.py" \
+"$VALIDATION_VENV_DIR/bin/python" "$SCRIPTS_DIR/validate_ol_events.py" \
 --event_base_dir="$PRODUCER_OUTPUT_EVENTS_DIR" \
 --spec_base_dir="$SPECS_BASE_DIR" \
 --target="$REPORT_PATH" \

--- a/producer/dbt/scenarios/csv_to_postgres/config.json
+++ b/producer/dbt/scenarios/csv_to_postgres/config.json
@@ -265,6 +265,57 @@
           ]
         }
       }
+    },
+    {
+      "name": "customers_data_quality_assertions_test",
+      "path": "events/customers/data_quality_event.json",
+      "openlineage_versions": {
+        "min": "1.38.0"
+      },
+      "tags": {
+        "facets": [
+          "dataQualityAssertions"
+        ],
+        "lineage_level": {
+          "postgres": [
+            "dataset"
+          ]
+        }
+      }
+    },
+    {
+      "name": "orders_data_quality_assertions_test",
+      "path": "events/orders/data_quality_event.json",
+      "openlineage_versions": {
+        "min": "1.38.0"
+      },
+      "tags": {
+        "facets": [
+          "dataQualityAssertions"
+        ],
+        "lineage_level": {
+          "postgres": [
+            "dataset"
+          ]
+        }
+      }
+    },
+    {
+      "name": "analytics_data_quality_assertions_test",
+      "path": "events/analytics/data_quality_event.json",
+      "openlineage_versions": {
+        "min": "1.38.0"
+      },
+      "tags": {
+        "facets": [
+          "dataQualityAssertions"
+        ],
+        "lineage_level": {
+          "postgres": [
+            "dataset"
+          ]
+        }
+      }
     }
   ]
 }

--- a/producer/dbt/scenarios/csv_to_postgres/events/analytics/data_quality_event.json
+++ b/producer/dbt/scenarios/csv_to_postgres/events/analytics/data_quality_event.json
@@ -12,17 +12,17 @@
         "dataQualityAssertions": {
           "assertions": [
             {
-              "assertion": "not_null",
-              "column": "customer_id",
-              "success": true
-            },
-            {
-              "assertion": "not_null",
+              "assertion": "not_null_customer_analytics_total_revenue",
               "column": "total_revenue",
               "success": true
             },
             {
-              "assertion": "unique",
+              "assertion": "not_null_customer_analytics_customer_id",
+              "column": "customer_id",
+              "success": true
+            },
+            {
+              "assertion": "unique_customer_analytics_customer_id",
               "column": "customer_id",
               "success": true
             }

--- a/producer/dbt/scenarios/csv_to_postgres/events/analytics/data_quality_event.json
+++ b/producer/dbt/scenarios/csv_to_postgres/events/analytics/data_quality_event.json
@@ -1,0 +1,34 @@
+{
+  "eventType": "COMPLETE",
+  "job": {
+    "namespace": "dbt",
+    "name": "dbt_test.main.openlineage_compatibility_test.customer_analytics.test"
+  },
+  "inputs": [
+    {
+      "name": "dbt_test.main.customer_analytics",
+      "namespace": "postgres://localhost:5432",
+      "facets": {
+        "dataQualityAssertions": {
+          "assertions": [
+            {
+              "assertion": "not_null",
+              "column": "customer_id",
+              "success": true
+            },
+            {
+              "assertion": "not_null",
+              "column": "total_revenue",
+              "success": true
+            },
+            {
+              "assertion": "unique",
+              "column": "customer_id",
+              "success": true
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/producer/dbt/scenarios/csv_to_postgres/events/customers/data_quality_event.json
+++ b/producer/dbt/scenarios/csv_to_postgres/events/customers/data_quality_event.json
@@ -1,0 +1,29 @@
+{
+  "eventType": "COMPLETE",
+  "job": {
+    "namespace": "dbt",
+    "name": "dbt_test.main.openlineage_compatibility_test.stg_customers.test"
+  },
+  "inputs": [
+    {
+      "name": "dbt_test.main.stg_customers",
+      "namespace": "postgres://localhost:5432",
+      "facets": {
+        "dataQualityAssertions": {
+          "assertions": [
+            {
+              "assertion": "not_null",
+              "column": "customer_id",
+              "success": true
+            },
+            {
+              "assertion": "unique",
+              "column": "customer_id",
+              "success": true
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/producer/dbt/scenarios/csv_to_postgres/events/customers/data_quality_event.json
+++ b/producer/dbt/scenarios/csv_to_postgres/events/customers/data_quality_event.json
@@ -12,12 +12,12 @@
         "dataQualityAssertions": {
           "assertions": [
             {
-              "assertion": "not_null",
+              "assertion": "not_null_stg_customers_customer_id",
               "column": "customer_id",
               "success": true
             },
             {
-              "assertion": "unique",
+              "assertion": "unique_stg_customers_customer_id",
               "column": "customer_id",
               "success": true
             }

--- a/producer/dbt/scenarios/csv_to_postgres/events/orders/data_quality_event.json
+++ b/producer/dbt/scenarios/csv_to_postgres/events/orders/data_quality_event.json
@@ -12,17 +12,17 @@
         "dataQualityAssertions": {
           "assertions": [
             {
-              "assertion": "not_null",
+              "assertion": "not_null_stg_orders_customer_id",
               "column": "customer_id",
               "success": true
             },
             {
-              "assertion": "not_null",
+              "assertion": "not_null_stg_orders_order_id",
               "column": "order_id",
               "success": true
             },
             {
-              "assertion": "unique",
+              "assertion": "unique_stg_orders_order_id",
               "column": "order_id",
               "success": true
             }

--- a/producer/dbt/scenarios/csv_to_postgres/events/orders/data_quality_event.json
+++ b/producer/dbt/scenarios/csv_to_postgres/events/orders/data_quality_event.json
@@ -1,0 +1,34 @@
+{
+  "eventType": "COMPLETE",
+  "job": {
+    "namespace": "dbt",
+    "name": "dbt_test.main.openlineage_compatibility_test.stg_orders.test"
+  },
+  "inputs": [
+    {
+      "name": "dbt_test.main.stg_orders",
+      "namespace": "postgres://localhost:5432",
+      "facets": {
+        "dataQualityAssertions": {
+          "assertions": [
+            {
+              "assertion": "not_null",
+              "column": "customer_id",
+              "success": true
+            },
+            {
+              "assertion": "not_null",
+              "column": "order_id",
+              "success": true
+            },
+            {
+              "assertion": "unique",
+              "column": "order_id",
+              "success": true
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/producer/dbt/scenarios/csv_to_postgres/test/run.sh
+++ b/producer/dbt/scenarios/csv_to_postgres/test/run.sh
@@ -86,6 +86,7 @@ EOF
 
 dbt-ol seed --project-dir="$RUNNER_DIR" --profiles-dir="$RUNNER_DIR" --target=postgres --no-version-check
 dbt-ol run --project-dir="$RUNNER_DIR" --profiles-dir="$RUNNER_DIR" --target=postgres --no-version-check
+dbt-ol test --project-dir="$RUNNER_DIR" --profiles-dir="$RUNNER_DIR" --target=postgres --no-version-check
 
 EVENTS_FILE="${PRODUCER_OUTPUT_EVENTS_DIR}/events.jsonl"
 if [[ ! -f "$EVENTS_FILE" ]]; then


### PR DESCRIPTION
Builds on the dbt producer compatibility test merged in #211.

Adds `dbt-ol test` to `test/run.sh` so test-phase events are captured alongside seed and run. Includes three expected `data_quality_event.json` files for `stg_customers`, `stg_orders`, and `customer_analytics`, each registered in `config.json` under the `dataQualityAssertions` facet tag. Event content derived from actual `dbt-ol 1.23.0` output against PostgreSQL 15.

Also fixes the local debugging section of `producer/dbt/README.md`, which still referenced `run_dbt_tests.sh` — a script removed in #211 — replacing it with the current `docker compose` + `run.sh` workflow.