### PR TITLE
remove iceberg-core jar from jar list to avoid conflicts

### DIFF
--- a/producer/spark_dataproc/runner/get_openlineage_jar.sh
+++ b/producer/spark_dataproc/runner/get_openlineage_jar.sh
@@ -27,7 +27,6 @@ postgresql_url="gs://open-lineage-e2e/jars/postgresql-42.5.6.jar"
 delta_spark_url="gs://open-lineage-e2e/jars/delta-spark_2.12-3.3.1.jar"
 delta_storage_url="gs://open-lineage-e2e/jars/delta-storage-3.3.1.jar"
 iceberg_spark_runtime_url="gs://open-lineage-e2e/jars/iceberg-spark-runtime-3.5_2.12-1.10.0.jar"
-iceberg_core_url="gs://open-lineage-e2e/jars/iceberg-core-1.10.0.jar"
 iceberg_gcp_bundle_url="gs://open-lineage-e2e/jars/iceberg-gcp-bundle-1.10.0.jar"
 iceberg_bigquery_url="gs://open-lineage-e2e/jars/iceberg-bigquery-1.10.0.jar"
 
@@ -41,7 +40,6 @@ if [[ "${SKIP_ICEBERG_AND_DELTA}" == "" ]]; then
   gsutil cp -P "${delta_spark_url}" "${VM_SPARK_JARS_DIR}/"
   gsutil cp -P "${delta_storage_url}" "${VM_SPARK_JARS_DIR}/"
   gsutil cp -P "${iceberg_spark_runtime_url}" "${VM_SPARK_JARS_DIR}/"
-  gsutil cp -P "${iceberg_core_url}" "${VM_SPARK_JARS_DIR}/"
   gsutil cp -P "${iceberg_gcp_bundle_url}" "${VM_SPARK_JARS_DIR}/"
   gsutil cp -P "${iceberg_bigquery_url}" "${VM_SPARK_JARS_DIR}/"
 fi


### PR DESCRIPTION
remove iceberg core jar from initialization script to avoid conflicts between core and spark-runtime-dependencies